### PR TITLE
fix pricing policy filter

### DIFF
--- a/src/explorer/views/Farms.vue
+++ b/src/explorer/views/Farms.vue
@@ -222,7 +222,7 @@ export default class Farms extends Vue {
     const values = [...map.values()];
 
     for (let i = 0; i < values.length; i++) {
-      if (values[i] === value) return keys[i];
+      if (values[i] === value) return +keys[i];
     }
 
     return null;


### PR DESCRIPTION
### Description

- graphql returns error because the pricing policy id is a string

### Changes

- changes pricing policy id to int

### Related issues

- https://github.com/threefoldtech/tfgrid_dashboard/issues/40