### PR TITLE
Development tfexplorer input validation

### DIFF
--- a/src/explorer/components/ComparisonFilter.vue
+++ b/src/explorer/components/ComparisonFilter.vue
@@ -2,13 +2,17 @@
   <v-card flat color="transparent">
     <v-subheader>{{ label.toLocaleUpperCase() }}</v-subheader>
     <v-text-field
-      type="number"
+      type="text"
       :label="label"
       solo
       :prefix="prefix"
       clearable
       v-model="value"
+      @input.native="validated($event.srcElement.value, key2)"
     />
+    <v-alert dense type="error" v-if="errorMsg">
+        {{ errorMsg }}
+    </v-alert>
   </v-card>
 </template>
 <script lang="ts">
@@ -16,6 +20,7 @@ import { MutationTypes } from "../store/mutations";
 import { IState } from "../store/state";
 import { IOP } from "../utils/filters";
 import { Component, Prop, Vue } from "vue-property-decorator";
+import { inputValidation } from "../utils/validations"
 
 @Component({})
 export default class ComparisonFilter extends Vue {
@@ -43,6 +48,12 @@ export default class ComparisonFilter extends Vue {
       key2: this.key2,
       value: true,
     });
+  }
+
+  errorMsg:any = ''
+  validated(value: string, key: string): string{
+    this.errorMsg = inputValidation(value, key);
+    return this.errorMsg;
   }
 
   destroyed() {

--- a/src/explorer/components/InFilter.vue
+++ b/src/explorer/components/InFilter.vue
@@ -11,7 +11,8 @@
       prefix="in:"
       solo
       type="text"
-    >
+      @input.native="checkInputValidation($event.srcElement.value, key2)"
+      >
       <template v-slot:selection="{ attrs, item, select, selected }">
         <v-chip
           v-bind="attrs"
@@ -24,6 +25,9 @@
         </v-chip>
       </template>
     </v-combobox>
+    <v-alert dense type="error" v-if="errorMsg">
+        {{ errorMsg }}
+    </v-alert>
   </v-card>
 </template>
 <script lang="ts">
@@ -70,6 +74,25 @@ export default class InFilter extends Vue {
     if (idx > -1) {
       items.splice(idx, 1);
       this.items = items;
+    }
+  }
+
+  errorMsg:any = ''
+  checkInputValidation(value: string, key: string) {
+    // value: Current value of the input.
+    // key: Current key of the input, e.g. [nodeId,farmId]..etc
+
+    const numericFields :string[] = ['nodeId', 'farmId', 'twinId', 'freePublicIPs']
+    if(numericFields.includes(key)) {
+      if(isNaN(+value)
+        || value.startsWith("+")
+        || value.startsWith("-")
+        || value.startsWith("0")
+        || value.includes("e")){
+        this.errorMsg = 'This field must be a number.'; return;
+      } else {
+        this.errorMsg = ''; return;
+      }
     }
   }
 

--- a/src/explorer/components/InFilter.vue
+++ b/src/explorer/components/InFilter.vue
@@ -11,7 +11,7 @@
       prefix="in:"
       solo
       type="text"
-      @input.native="checkInputValidation($event.srcElement.value, key2)"
+      @input.native="validated($event.srcElement.value, key2)"
       >
       <template v-slot:selection="{ attrs, item, select, selected }">
         <v-chip
@@ -34,6 +34,7 @@
 import { MutationTypes } from "../store/mutations";
 import { IState } from "../store/state";
 import { Component, Prop, Vue } from "vue-property-decorator";
+import { inputValidation } from "../utils/validations"
 
 @Component({})
 export default class InFilter extends Vue {
@@ -78,22 +79,9 @@ export default class InFilter extends Vue {
   }
 
   errorMsg:any = ''
-  checkInputValidation(value: string, key: string) {
-    // value: Current value of the input.
-    // key: Current key of the input, e.g. [nodeId,farmId]..etc
-
-    const numericFields :string[] = ['nodeId', 'farmId', 'twinId', 'freePublicIPs']
-    if(numericFields.includes(key)) {
-      if(isNaN(+value)
-        || value.startsWith("+")
-        || value.startsWith("-")
-        || value.startsWith("0")
-        || value.includes("e")){
-        this.errorMsg = 'This field must be a number.'; return;
-      } else {
-        this.errorMsg = ''; return;
-      }
-    }
+  validated(value: string, key: string): string{
+    this.errorMsg = inputValidation(value, key);
+    return this.errorMsg;
   }
 
   created() {

--- a/src/explorer/components/InFilterV2.vue
+++ b/src/explorer/components/InFilterV2.vue
@@ -12,13 +12,18 @@
       @keydown="search"
       v-model="content"
       :multiple="options.multiple"
+      @input.native="validated($event.srcElement.value, options.key)"
     />
+    <v-alert dense type="error" v-if="errorMsg">
+        {{ errorMsg }}
+    </v-alert>
   </v-card>
 </template>
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
 import IFilterOptions from "../types/FilterOptions";
 import { debounce } from "lodash";
+import { inputValidation } from "../utils/validations"
 
 type TContent = string | number | Array<string | number>;
 
@@ -60,6 +65,12 @@ export default class InFilterV2 extends Vue {
     if (this.options.init) {
       this._search({ target: { value: null } } as any);
     }
+  }
+
+  errorMsg:any = ''
+  validated(value: string, key: string): string{
+    this.errorMsg = inputValidation(value, key);
+    return this.errorMsg;
   }
 }
 </script>

--- a/src/explorer/components/RangeFilter.vue
+++ b/src/explorer/components/RangeFilter.vue
@@ -20,6 +20,7 @@
                   hide-details
                   single-line
                   type="number"
+                  @input.native="validated($event.srcElement.value, key2)"
                   @input="onChange({ min: $event })"
                   style="width: 52px; text-align: center"
                 ></v-text-field>
@@ -45,12 +46,16 @@
         </v-col>
       </v-row>
     </v-card-text>
+    <v-alert dense type="error" v-if="errorMsg">
+        {{ errorMsg }}
+    </v-alert>
   </v-card>
 </template>
 <script lang="ts">
 import { MutationTypes } from "../store/mutations";
 import { Component, Prop, Vue } from "vue-property-decorator";
 import toTera from "../filters/toTera";
+// import { inputValidation } from "../utils/validations"
 
 @Component({})
 export default class RangeFilter extends Vue {
@@ -96,6 +101,15 @@ export default class RangeFilter extends Vue {
       min ? min * multiplier : __min,
       max ? max * multiplier : __max,
     ];
+  }
+
+  errorMsg:any = ''
+  validated(value: string, key: string){
+    console.log(value)
+    if (+value < 0){
+      this.errorMsg = "Number must be positive."; return;
+    }
+    this.errorMsg = ''
   }
 
   created() {

--- a/src/explorer/components/RangeFilter.vue
+++ b/src/explorer/components/RangeFilter.vue
@@ -105,7 +105,6 @@ export default class RangeFilter extends Vue {
 
   errorMsg:any = ''
   validated(value: string, key: string){
-    console.log(value)
     if (+value < 0){
       this.errorMsg = "Number must be positive."; return;
     }

--- a/src/explorer/types/FilterOptions.ts
+++ b/src/explorer/types/FilterOptions.ts
@@ -8,5 +8,6 @@ export default interface IFilterOptions {
   type?: "text" | "number";
   init?: boolean;
   symbol: string;
+  key: string;
   getValue?: (filter: IFilterOptions) => any;
 }

--- a/src/explorer/utils/validations.ts
+++ b/src/explorer/utils/validations.ts
@@ -2,8 +2,13 @@ export function inputValidation(value: string, key: string) : string {
     // value: Current value of the input.
     // key: Current key of the input, e.g. [nodeId,farmId]..etc
 
-    const numericFields :string[] = ['nodeId', 'farmId', 'twinId', 'freePublicIPs'];
-    const textualFields :string[] = ['countryFullName', 'farmingPolicyName', 'certificationType'];
+    const numericFields :string[] = [
+        'nodeId', 'farmId', 'twinId', 'freePublicIPs', 'farmID'
+    ];
+    const textualFields :string[] = [
+        'countryFullName', 'farmingPolicyName', 'certificationType',
+        'farmName', 'pricingPolicyId',
+    ];
     const specialChars = /[ `!@#$%^&*()+\-=[\]{};':"\\|,.<>/?~]/;
     let errorMsg = ''
 

--- a/src/explorer/utils/validations.ts
+++ b/src/explorer/utils/validations.ts
@@ -4,13 +4,13 @@ export function inputValidation(value: string, key: string) : string {
 
     const numericFields :string[] = ['nodeId', 'farmId', 'twinId', 'freePublicIPs'];
     const textualFields :string[] = ['countryFullName', 'farmingPolicyName', 'certificationType'];
-    const specialChars = /[ `!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/;
+    const specialChars = /[ `!@#$%^&*()+\-=[\]{};':"\\|,.<>/?~]/;
     let errorMsg = ''
 
     if(numericFields.includes(key)){
         if(isNaN(+value)
         || specialChars.test(value)
-        || value.startsWith("0")
+        || +value < 0
         || value.includes("e")){
             errorMsg = 'This field must be a number.'; return errorMsg;
         }

--- a/src/explorer/utils/validations.ts
+++ b/src/explorer/utils/validations.ts
@@ -1,0 +1,24 @@
+export function inputValidation(value: string, key: string) : string {
+    // value: Current value of the input.
+    // key: Current key of the input, e.g. [nodeId,farmId]..etc
+
+    const numericFields :string[] = ['nodeId', 'farmId', 'twinId', 'freePublicIPs'];
+    const textualFields :string[] = ['countryFullName', 'farmingPolicyName', 'certificationType'];
+    const specialChars = /[ `!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/;
+    let errorMsg = ''
+
+    if(numericFields.includes(key)){
+        if(isNaN(+value)
+        || specialChars.test(value)
+        || value.startsWith("0")
+        || value.includes("e")){
+            errorMsg = 'This field must be a number.'; return errorMsg;
+        }
+    } else if (textualFields.includes(key)) {
+        if(specialChars.test(value)){
+            errorMsg = 'This field does not accept special characters.'; return errorMsg;
+        }
+    }
+    errorMsg = ''
+    return errorMsg
+}

--- a/src/explorer/views/Farms.vue
+++ b/src/explorer/views/Farms.vue
@@ -280,8 +280,8 @@ export default class Farms extends Vue {
       items: () => Promise.resolve([]),
       value: [],
       multiple: true,
-      type: "number",
       symbol: "farmId_in",
+      key: "farmID",
     },
     {
       component: InFilterV2,
@@ -300,6 +300,7 @@ export default class Farms extends Vue {
       value: [],
       multiple: true,
       symbol: "name_in",
+      key: "farmName",
     },
     {
       component: InFilterV2,
@@ -307,9 +308,9 @@ export default class Farms extends Vue {
       label: "Filter By Twin ID",
       items: (_) => Promise.resolve([]),
       value: [],
-      type: "number",
       multiple: true,
       symbol: "twinId_in",
+      key: "twinId",
     },
     {
       component: InFilterV2,
@@ -320,6 +321,7 @@ export default class Farms extends Vue {
       init: true,
       multiple: true,
       symbol: "certificationType_in",
+      key: "certificationType",
     },
     {
       component: InFilterV2,
@@ -330,6 +332,7 @@ export default class Farms extends Vue {
       init: true,
       multiple: true,
       symbol: "pricingPolicyId_in",
+      key: "pricingPolicyId",
       getValue: (f) => {
         return (f.value as string[]).map(this.getKeyByValue.bind(this));
       },


### PR DESCRIPTION
### Description
Added some validations on [NodeFilter, FarmFilter] 

### Changes
- [x] Replace `type` number of input's by `text` type, type `number` was accept `e, -, +`
- [x] Special characters are now not allowed in any field that accepts `text` type.
- [x] If the incoming input value starts with `0` or contains any of `e, -, +` filters will not work and user will see an alert error under input field that tells him this is wrong type and must be a valid number

### Related Issues
[#96 - TF Explorer input validation](https://github.com/threefoldtech/tfgrid_dashboard/issues/96)
