### PR TITLE
change string filters to number and change certification query

### DIFF
--- a/src/explorer/graphql/api.ts
+++ b/src/explorer/graphql/api.ts
@@ -109,7 +109,7 @@ export interface IFarm {
   name: string;
   twinId: number;
   pricingPolicyId: number;
-  certificationType: "Diy" | "Certified";
+  certificationType: "Gold" | "NotCertified";
   publicIPs: IPublicIPs[];
   stellarAddress?: string;
   totalPublicIp: number;

--- a/src/explorer/store/mutations.ts
+++ b/src/explorer/store/mutations.ts
@@ -67,10 +67,10 @@ export default {
 
         totalPublicIPs: farms.find(
           (farm: any) => farm.farmId === nodes[i].farmId
-        ).publicIps.length,
+        )?.publicIps.length,
         freePublicIPs: farms
           .find((farm: any) => farm.farmId === nodes[i].farmId)
-          .publicIps.filter((ip: any) => ip.contractId === 0).length,
+          ?.publicIps.filter((ip: any) => ip.contractId === 0).length,
         hru: nodes[i].total_resources.hru,
         sru: nodes[i].total_resources.sru,
         cru: nodes[i].total_resources.cru,

--- a/src/explorer/views/Farms.vue
+++ b/src/explorer/views/Farms.vue
@@ -186,7 +186,6 @@ export default class Farms extends Vue {
   public onUpdatePage() {
     if (this.items) return;
     this.loading = true;
-    console.log("rawda", this._vars)
     this.$apollo
       .query<IFetchPaginatedData<IFarm>>({
         query: getFarmsQuery,

--- a/src/explorer/views/Farms.vue
+++ b/src/explorer/views/Farms.vue
@@ -186,6 +186,7 @@ export default class Farms extends Vue {
   public onUpdatePage() {
     if (this.items) return;
     this.loading = true;
+    console.log("rawda", this._vars)
     this.$apollo
       .query<IFetchPaginatedData<IFarm>>({
         query: getFarmsQuery,
@@ -322,7 +323,7 @@ export default class Farms extends Vue {
       component: InFilterV2,
       chip_label: "Certification Type",
       label: "Filter By Certification Type",
-      items: (_) => Promise.resolve(["Diy", "Certified"]),
+      items: (_) => Promise.resolve(["Gold", "NotCertified"]),
       value: [],
       init: true,
       multiple: true,

--- a/src/explorer/views/Farms.vue
+++ b/src/explorer/views/Farms.vue
@@ -282,6 +282,9 @@ export default class Farms extends Vue {
       multiple: true,
       symbol: "farmId_in",
       key: "farmID",
+      getValue: (f) => {
+        return (f.value as string[]).map((x) => +x );
+      },
     },
     {
       component: InFilterV2,
@@ -311,6 +314,9 @@ export default class Farms extends Vue {
       multiple: true,
       symbol: "twinId_in",
       key: "twinId",
+      getValue: (f) => {
+        return (f.value as string[]).map((x) => +x );
+      },
     },
     {
       component: InFilterV2,
@@ -320,7 +326,7 @@ export default class Farms extends Vue {
       value: [],
       init: true,
       multiple: true,
-      symbol: "certificationType_in",
+      symbol: "certification_in",
       key: "certificationType",
     },
     {


### PR DESCRIPTION
- change number filters from string to number in farms
- change `certification_in` from `certificationType_in`
- change certification options in farms to "Gold" and "NotCertified"
- solve publicips error in console (just needed a check)

### Related issues

 - https://github.com/threefoldtech/tfgrid_dashboard/issues/97


- we have a problem when we filter using certification