### PR TITLE
Updated certification type when it's empty

### DIFF
--- a/src/explorer/components/NodeDetails.vue
+++ b/src/explorer/components/NodeDetails.vue
@@ -94,7 +94,7 @@
             <v-list-item-content>
               <v-list-item-title> Certification Type </v-list-item-title>
             </v-list-item-content>
-            {{ node.certificationType }}
+            {{ node.certificationType || "Not Certified" }}
           </v-list-item>
           <v-divider />
 


### PR DESCRIPTION
### Description
Updated the certificationType field in node Details to show "Not certified" when the node isn't certified instead of leaving the field empty.
### Related Issues
#294