### PR TITLE
fix circular progress in node details

### DIFF
--- a/src/explorer/components/NodeUsedResources.vue
+++ b/src/explorer/components/NodeUsedResources.vue
@@ -22,13 +22,24 @@
           >
             <div>{{ item.name }}</div>
             <div class="text-center">
+              <!-- in case of total_resources is NaN "zero" -->
               <v-progress-circular
-                :value="item.value"
+                :value="isNaN(item.value) ? 0 : item.value"
                 :size="150"
                 :width="15"
                 color="primary"
-                >{{ item.value }}%</v-progress-circular
-              >
+                v-if="isNaN(item.value)"
+                >NA
+              </v-progress-circular>
+              <!-- in other case-->
+              <v-progress-circular
+                :value="isNaN(item.value) ? 0 : item.value"
+                :size="150"
+                :width="15"
+                color="primary"
+                v-else
+                >{{ item.value }}%
+              </v-progress-circular>
             </div>
           </div>
         </div>
@@ -78,7 +89,7 @@ export default class NodeUsedResources extends Vue {
               ? (res.capacity.used_resources[i] /
                   res.capacity.total_resources[i]) *
                 100
-              : 100; // prettier-ignore, validate if the total is zero so the usage is 100 else do the division
+              : NaN; // prettier-ignore, validate if the total is zero so the usage is set to NaN else do the division
           return {
             id: idx + 1,
             value: value.toFixed(2),

--- a/src/portal/components/FarmNodesTable.vue
+++ b/src/portal/components/FarmNodesTable.vue
@@ -232,18 +232,23 @@
                                 :rotate="-90"
                                 :size="100"
                                 :width="15"
-                                :value="getPercentage(key)"
+                                :value="isNaN(getPercentage(key))? 0: getPercentage(key)"
                                 color="light-green darken-2"
                               />
+                              
                               <template v-if="item.resourcesUsed">
                                 <span v-if="item.resourcesTotal[key] > 1000">
                                   {{ byteToGB(item.resourcesUsed[key]) }} /
                                   {{ byteToGB(item.resourcesTotal[key]) }} GB
                                 </span>
+                                <span v-else-if='item.resourcesTotal[key]== 0' >
+                                  NA
+                                </span>
                                 <span v-else>
                                   {{ item.resourcesUsed[key] }} /
                                   {{ item.resourcesTotal[key] }}
                                 </span>
+
                               </template>
                             </template>
                           </v-tooltip>
@@ -877,5 +882,8 @@ export default class FarmNodesTable extends Vue {
     if (reservedResources === 0 && totalResources === 0) return 0;
     return (reservedResources / totalResources) * 100;
   }
+  created() {
+  console.log({fn: this.getPercentage.bind(this)})
+}
 }
 </script>

--- a/src/portal/components/FarmNodesTable.vue
+++ b/src/portal/components/FarmNodesTable.vue
@@ -235,7 +235,6 @@
                                 :value="isNaN(getPercentage(key))? 0: getPercentage(key)"
                                 color="light-green darken-2"
                               />
-                              
                               <template v-if="item.resourcesUsed">
                                 <span v-if="item.resourcesTotal[key] > 1000">
                                   {{ byteToGB(item.resourcesUsed[key]) }} /
@@ -248,7 +247,6 @@
                                   {{ item.resourcesUsed[key] }} /
                                   {{ item.resourcesTotal[key] }}
                                 </span>
-
                               </template>
                             </template>
                           </v-tooltip>
@@ -882,8 +880,5 @@ export default class FarmNodesTable extends Vue {
     if (reservedResources === 0 && totalResources === 0) return 0;
     return (reservedResources / totalResources) * 100;
   }
-  created() {
-  console.log({fn: this.getPercentage.bind(this)})
-}
 }
 </script>


### PR DESCRIPTION
In #321, this issue occurs in two places: portal and explorer.
I don't think there are other places this issue may occur.

- in the explorer: when the **getNodeUsedResources(nodeId: number)**  get invoked, if the **.total_resources = 0** it was return **100**, but now I set it to return _**NaN**_, and **v-progress-circular** with if statement to display _**NA**_ if the **item.value** is **NaN**.
result :![Screenshot from 2022-10-28 15-53-08](https://user-images.githubusercontent.com/62248851/198874790-1d884861-3b55-42d0-8ad5-140082416621.png)
- in the portal: add an **else-if** statement in case of **0/0** to set to _**NA**_.
result:![Screenshot from 2022-10-30 12-33-53](https://user-images.githubusercontent.com/62248851/198874766-1e631d9a-5e98-4814-8677-83f4b51ad29f.png)
