### PR TITLE
Adjusting the public config nodeId

### DIFF
--- a/src/portal/components/FarmNodesTable.vue
+++ b/src/portal/components/FarmNodesTable.vue
@@ -288,7 +288,7 @@
       >
         <v-card>
           <v-card-title class="text-h5">
-            Add a public config to your node with ID: {{ nodeToEdit.id }}
+            Add a public config to your node with ID: {{ nodeToEdit.nodeId }}
           </v-card-title>
 
           <v-card-text class="text">


### PR DESCRIPTION
###  Description 
Showing  nodeId instead of id when editing the public config of a node.

### Related Issues 

#342