### PR TITLE
Fixing calculator children icons when closed

### DIFF
--- a/src/Dashboard.vue
+++ b/src/Dashboard.vue
@@ -332,6 +332,7 @@ export default class Dashboard extends Vue {
       if (this.mini){
         this.routes[0].active = false;
         this.routes[1].active = false;
+        this.routes[2].active = false;        
       }
     });
   }
@@ -490,18 +491,19 @@ export default class Dashboard extends Vue {
       label: "Calculators",
       icon: "calculator",
       prefix: "/calculator/",
+      active: this.mini ? false: true,
       children: [
         {
           label: "Resource Pricing",
           path: "calculator",
           icon: "currency-usd",
-          showBeforeLogIn: false,
+          showBeforeLogIn: true,
         },      
         {
           label: "Simulator",
           path: "simulator/",
           icon: "chart-scatter-plot",
-          showBeforeLogIn: false,
+          showBeforeLogIn: true,
           children: [
             {
               label: "Farming",

--- a/src/Dashboard.vue
+++ b/src/Dashboard.vue
@@ -330,9 +330,10 @@ export default class Dashboard extends Vue {
     this.$root.$on("closeSidebar", () => {
       this.mini = !this.mini;
       if (this.mini){
-        this.routes[0].active = false;
-        this.routes[1].active = false;
-        this.routes[2].active = false;        
+        const [portal, explorer, calculator] = this.routes;
+        portal.active = false;
+        explorer.active = false;
+        calculator.active = false;        
       }
     });
   }


### PR DESCRIPTION
### Description

collapsed calculator icon when closed

### Changes

changed the active state for the calculator when the sidebar is closed.

### Related Issues

- https://github.com/threefoldtech/tfgrid_dashboard/issues/370
