### PR TITLE
use gridproxy pagination on farms nodes table

### DIFF
--- a/src/portal/components/FarmNodesTable.vue
+++ b/src/portal/components/FarmNodesTable.vue
@@ -21,6 +21,7 @@
         :expanded.sync="expanded"
         :loading="loadingNodes"
         show-expand
+        :disable-sort="true"
         item-key="id"
         class="elevation-1"
         sort-by="id"

--- a/src/portal/components/FarmNodesTable.vue
+++ b/src/portal/components/FarmNodesTable.vue
@@ -1,24 +1,34 @@
 <template>
   <div>
+    <div style="padding-top:20px"></div>
 
+    <!-- Show only if you have nodes -->
     <div v-if="nodes.length">
-      <v-text-field
+
+      <!-- Searching/Sorting is disabled for now -->
+      <!-- <v-text-field
         v-model="searchTerm"
         color="primary darken-2"
         label="Search by node ID, serial number, certification, farming policy ID"
-      ></v-text-field>
+      ></v-text-field> -->
+
+
+      
       <v-data-table
         :headers="headers"
-        :items="filteredNodes()"
+        :items="nodes"
         :single-expand="true"
         :expanded.sync="expanded"
-        item-key="id"
+        :loading="loadingNodes"
         show-expand
+        item-key="id"
         class="elevation-1"
         sort-by="id"
+        :server-items-length="+count"
+        @update:options="onOptionChange($event.page, $event.itemsPerPage)"
       >
         <template v-slot:top>
-          <v-toolbar flat>
+          <v-toolbar flat class="primary white--text">
             <v-toolbar-title>Your Farm Nodes</v-toolbar-title>
             <v-btn
               v-if="network == 'main'"
@@ -65,6 +75,7 @@
             <span>Add a public config</span>
           </v-tooltip>
         </template>
+
         <!--expanded node view-->
         <template v-slot:expanded-item="{ headers, item }">
           <td
@@ -284,6 +295,7 @@
           </td>
         </template>
       </v-data-table>
+
       <!--public config dialog-->
       <v-dialog
         v-model="openPublicConfigDialog"
@@ -389,6 +401,7 @@
           </v-card-actions>
         </v-card>
       </v-dialog>
+
       <!-- delete item dialog-->
       <v-dialog
         v-model="openDeleteDialog"
@@ -450,18 +463,24 @@
         </v-card>
       </v-dialog>
     </div>
-    <div v-if="loadingNodes">
+
+    <div v-if="initLoading">
       <v-data-table
         loading
         loading-text="loading nodes.."
-      ></v-data-table>
+        :headers="headers"
+      >
+      <template v-slot:top>
+          <v-toolbar flat class="primary white--text">
+            <v-toolbar-title>Your Farm Nodes</v-toolbar-title>
+          </v-toolbar>
+        </template>
+    </v-data-table>
     </div>
   </div>
 </template>
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
-
-import moment from "moment";
 import { default as PrivateIp } from "private-ip";
 import {
   byteToGB,
@@ -554,6 +573,8 @@ export default class FarmNodesTable extends Vue {
   openPublicConfigDialog = false;
   @Prop({ required: true }) nodes!: nodeInterface[];
   @Prop({ required: true }) loadingNodes!: boolean;
+  @Prop({ required: true }) initLoading!: boolean;
+  @Prop({ required: true }) count!: string;
   searchTerm = "";
   ip4 = "";
   gw4 = "";
@@ -571,28 +592,34 @@ export default class FarmNodesTable extends Vue {
   gw6ErrorMessage = "";
   domainErrorMessage = "";
   receipts = [];
+
   updated() {
     this.receiptsPanel = [];
   }
-  filteredNodes() {
-    let nodes = this.nodes;
-    if (this.nodes.length > 0) {
-      nodes = this.nodes.filter(
-        (node: nodeInterface) =>
-          `${node.nodeId}`.includes(this.searchTerm) ||
-          node.serialNumber
-            ?.toLowerCase()
-            .includes(this.searchTerm.toLowerCase()) ||
-          node.certificationType
-            ?.toLowerCase()
-            .includes(this.searchTerm.toLowerCase()) ||
-          `${node.farmingPolicyId}`.includes(this.searchTerm)
-      );
-    }
-    return nodes.map((node) => {
-      return { ...node };
-    });
+  onOptionChange(pageNumber:number, pageSize: number) {
+    this.$emit('options-changed', {pageNumber, pageSize})
   }
+
+  // filteredNodes() {
+  //   let nodes = this.nodes;
+  //   if (this.nodes.length > 0) {
+  //     nodes = this.nodes.filter(
+  //       (node: nodeInterface) =>
+  //         `${node.nodeId}`.includes(this.searchTerm) ||
+  //         node.serialNumber
+  //           ?.toLowerCase()
+  //           .includes(this.searchTerm.toLowerCase()) ||
+  //         node.certificationType
+  //           ?.toLowerCase()
+  //           .includes(this.searchTerm.toLowerCase()) ||
+  //         `${node.farmingPolicyId}`.includes(this.searchTerm)
+  //     );
+  //   }
+  //   return nodes.map((node) => {
+  //     return { ...node };
+  //   });
+  // }
+
   downloadAllReceipts() {
     let docSum = new jsPDF();
     generateNodeSummary(docSum, this.nodes);

--- a/src/portal/views/Farms.vue
+++ b/src/portal/views/Farms.vue
@@ -1,29 +1,32 @@
 <template>
   <v-container fluid>
     <!-- show only if the twin has no farms -->
-    <div v-if="farms.length == 0">
-      <v-card
-        color="primary"
-        class="
-          white--text
-          my-3
-          pa-3
-          text-center
-          d-flex
-          justify-center
-          align-baseline
-        "
-      >
+    <v-card
+      color="primary"
+      class="
+        white--text
+        my-3
+        pa-3
+        text-center
+        d-flex
+        justify-center
+        align-baseline
+      "
+    >
+      <div v-if="farms.length == 0">
         <h3>Don't have any farms? Start by creating one:</h3>
+      </div>
+      <div v-if="farms.length != 0">
+        <h3>Create another farm:</h3>
+      </div>
 
-        <v-btn
-          @click="openCreateFarmDialog = true"
-          class="farm my-3 mx-5"
-          :loading="loadingCreateFarm"
-          >Create farm</v-btn
-        >
-      </v-card>
-    </div>
+      <v-btn
+        @click="openCreateFarmDialog = true"
+        class="farm my-3 mx-5"
+        :loading="loadingCreateFarm"
+        >Create farm</v-btn
+      >
+    </v-card>
 
     <!-- creating farm form -->
     <v-dialog
@@ -426,7 +429,7 @@ export default class FarmsView extends Vue {
   async getNodes() {
     this.farmsIds = this.farms.map((farm: any) => farm.id);
 
-    if (this.farmsIds.length == 0) return
+    if (this.farmsIds.length == 0) return;
 
     console.log(
       `Request nodes with params. farmids: ${this.farmsIds}, page: ${this.page}, size: ${this.size}`

--- a/src/portal/views/Farms.vue
+++ b/src/portal/views/Farms.vue
@@ -1,28 +1,38 @@
 <template>
   <v-container fluid>
+    <!-- show only if the twin has no farms -->
+    <div v-if="farms.length == 0">
+      <v-card
+        color="primary"
+        class="
+          white--text
+          my-3
+          pa-3
+          text-center
+          d-flex
+          justify-center
+          align-baseline
+        "
+      >
+        <h3>Don't have any farms? Start by creating one:</h3>
 
-    <v-card
-      color="primary"
-      class="white--text my-3 pa-3 text-center d-flex justify-center align-baseline"
-    >
-      <h3>Don't have any farms? Start by creating one:</h3>
+        <v-btn
+          @click="openCreateFarmDialog = true"
+          class="farm my-3 mx-5"
+          :loading="loadingCreateFarm"
+          >Create farm</v-btn
+        >
+      </v-card>
+    </div>
 
-      <v-btn
-        @click="openCreateFarmDialog = true"
-        class="farm my-3 mx-5"
-        :loading="loadingCreateFarm"
-      >Create farm</v-btn>
-    </v-card>
+    <!-- creating farm form -->
     <v-dialog
       transition="dialog-bottom-transition"
       v-model="openCreateFarmDialog"
       max-width="500"
     >
       <v-card>
-        <v-toolbar
-          color="primary"
-          class="white--text"
-        >Create Farm</v-toolbar>
+        <v-toolbar color="primary" class="white--text">Create Farm</v-toolbar>
         <v-card-text>
           <v-form v-model="isValidFarmName">
             <v-text-field
@@ -31,15 +41,15 @@
               required
               :error-messages="farmNameErrorMessage"
               :rules="[
-              () => !!farmName || 'This field is required',
-              farmNameCheck,
-              () =>
-                farmName.length <= 40 ||
-                'Name too long, only 40 characters permitted',
+                () => !!farmName || 'This field is required',
+                farmNameCheck,
                 () =>
-                farmName.length >= 3 ||
-                'Name should be more than or equal 3 characters',
-            ]"
+                  farmName.length <= 40 ||
+                  'Name too long, only 40 characters permitted',
+                () =>
+                  farmName.length >= 3 ||
+                  'Name should be more than or equal 3 characters',
+              ]"
             ></v-text-field>
           </v-form>
         </v-card-text>
@@ -49,19 +59,24 @@
             @click="createFarmFromName"
             :loading="loadingCreateFarm"
             :disabled="!isValidFarmName"
-          >Submit</v-btn>
+            >Submit</v-btn
+          >
           <v-btn
             @click="openCreateFarmDialog = false"
             color="grey lighten-2 black--text"
-          >Close</v-btn>
+            >Close</v-btn
+          >
         </v-card-actions>
       </v-card>
     </v-dialog>
+
     <v-text-field
       v-model="searchTerm"
       color="primary darken-2"
       label="Search by farm name or ID"
     ></v-text-field>
+
+    <!-- Farms table -->
     <v-data-table
       :headers="headers"
       :items="farms.length ? filteredFarms() : []"
@@ -75,20 +90,16 @@
       :loading-text="'loading farms ...'"
     >
       <template v-slot:top>
-        <v-toolbar
-          flat
-          class="primary white--text"
-        >
+        <v-toolbar flat class="primary white--text">
           <v-toolbar-title>Your Farms</v-toolbar-title>
           <v-spacer></v-spacer>
         </v-toolbar>
       </template>
+
+      <!-- details panel -->
       <template v-slot:expanded-item="{ item }">
         <td :colspan="headers.length">
-          <v-container
-            fluid
-            class="text-left"
-          >
+          <v-container fluid class="text-left">
             <v-row>
               <v-col>
                 <v-flex class="text-left pr-2">Farm ID</v-flex>
@@ -152,23 +163,21 @@
                     overflow: hidden;
                   "
                 >
-                  <v-row style="margin: 0;">
-                    <span style="font-size: small;">
+                  <v-row style="margin: 0">
+                    <span style="font-size: small">
                       {{ item.v2address }}
                     </span>
                   </v-row>
-                  <v-btn
-                    x-small
-                    @click="openV2AddressDialog = true"
-                  >Edit</v-btn>
+                  <v-btn x-small @click="openV2AddressDialog = true"
+                    >Edit</v-btn
+                  >
                 </v-row>
               </v-col>
               <v-col v-else>
                 <v-flex>
-                  <v-btn
-                    x-small
-                    @click="openV2AddressDialog = true"
-                  >Add V2 Address</v-btn>
+                  <v-btn x-small @click="openV2AddressDialog = true"
+                    >Add V2 Address</v-btn
+                  >
                 </v-flex>
               </v-col>
               <v-dialog
@@ -177,16 +186,18 @@
                 max-width="500"
               >
                 <v-card>
-                  <v-toolbar color="primary">Add/Edit V2 Stellar Address</v-toolbar>
+                  <v-toolbar color="primary"
+                    >Add/Edit V2 Stellar Address</v-toolbar
+                  >
                   <v-card-text>
                     <v-form v-model="isValidStellarV2Address">
                       <v-text-field
                         v-model="v2_address"
                         label="Stellar Wallet Address"
                         :rules="[
-          () => !!v2_address || 'This field is required',
-          () => stellarAddressCheck() || 'invalid address',
-        ]"
+                          () => !!v2_address || 'This field is required',
+                          () => stellarAddressCheck() || 'invalid address',
+                        ]"
                       >
                       </v-text-field>
                     </v-form>
@@ -195,13 +206,15 @@
                     <v-btn
                       @click="openV2AddressDialog = false"
                       color="grey lighten-2 black--text"
-                    >Close</v-btn>
+                      >Close</v-btn
+                    >
                     <v-btn
                       @click="addV2Address"
                       color="primary white--text"
                       :disabled="!isValidStellarV2Address"
                       :loading="loadingAddStellar"
-                    >Submit</v-btn>
+                      >Submit</v-btn
+                    >
                   </v-card-actions>
                 </v-card>
               </v-dialog>
@@ -216,7 +229,8 @@
                     x-small
                     v-bind:href="'https://v3.bootstrap.grid.tf/'"
                     target="blank"
-                  >view bootstrap</v-btn>
+                    >view bootstrap</v-btn
+                  >
                 </v-flex>
               </v-col>
             </v-row>
@@ -232,32 +246,42 @@
         </td>
       </template>
     </v-data-table>
+
+    <!-- Nodes table -->
     <FarmNodesTable
       :nodes="nodes"
       :loadingNodes="loadingNodes"
+      :initLoading="initLoading"
+      :count="count"
       @on:delete="getNodes()"
+      @options-changed="onOptionChange($event.pageNumber, $event.pageSize)"
     />
-    <v-dialog
-      v-model="openDeleteFarmDialog"
-      max-width="700px"
-    >
+
+    <!-- delete farm form -->
+    <v-dialog v-model="openDeleteFarmDialog" max-width="700px">
       <v-card>
-        <v-card-title class="text-h5">Are you certain you want to delete this farm?</v-card-title>
-        <v-card-text>This will delete the farm on the chain, this action is
-          irreversible</v-card-text>
+        <v-card-title class="text-h5"
+          >Are you certain you want to delete this farm?</v-card-title
+        >
+        <v-card-text
+          >This will delete the farm on the chain, this action is
+          irreversible</v-card-text
+        >
         <v-card-actions>
           <v-spacer></v-spacer>
           <v-btn
             color="grey lighten-2 black--text"
             text
             @click="openDeleteFarmDialog = false"
-          >Cancel</v-btn>
+            >Cancel</v-btn
+          >
           <v-btn
             color="primary white--text"
             text
             :loading="loadingDeleteFarm"
             @click="callDeleteFarm()"
-          >OK</v-btn>
+            >OK</v-btn
+          >
           <v-spacer></v-spacer>
         </v-card-actions>
       </v-card>
@@ -279,6 +303,7 @@ import {
   setFarmPayoutV2Address,
 } from "../lib/farms";
 import { StrKey } from "stellar-sdk";
+
 @Component({
   name: "FarmsView",
   components: { PublicIPTable, FarmNodesTable },
@@ -317,13 +342,25 @@ export default class FarmsView extends Vue {
   isValidStellarV2Address = false;
   loadingAddStellar = false;
   loadingFarms = true;
+
+  page = 1;
+  size = 10;
+  count = 0;
+  farmsIds: any;
+  initLoading = false;
+
+  // Life hooks
   async mounted() {
+    // not logged in? login: get farms, nodes
     this.address = this.$route.params.accountID;
     this.id = this.$route.query.twinID;
     if (this.$api) {
       this.farms = await getFarm(this.$api, this.id);
       this.loadingFarms = false;
-      this.nodes = this.getNodes();
+
+      this.initLoading = true;
+      await this.getNodes();
+      this.initLoading = false;
     } else {
       this.$router.push({
         name: "accounts",
@@ -331,22 +368,7 @@ export default class FarmsView extends Vue {
       });
     }
   }
-  @Watch("$route.query.twinID") async onPropertyChanged(
-    value: number,
-    oldValue: number
-  ) {
-    console.log(
-      `switching from account ${oldValue} farms to account ${value} farms`
-    );
-    this.farms = await getFarm(this.$api, value);
-    this.nodes = this.getNodes();
-  }
-  @Watch("farms.length") async onFarmCreation(value: number, oldValue: number) {
-    console.log(`there were ${oldValue} farms, now there is ${value} farms`);
-  }
-  @Watch("nodes.length") async onNodeDeleted(value: number, oldValue: number) {
-    console.log(`there were ${oldValue} nodes, now there is ${value} nodes`);
-  }
+
   async updated() {
     this.address = this.$route.params.accountID;
     this.id = this.$route.query.twinID;
@@ -362,6 +384,27 @@ export default class FarmsView extends Vue {
     this.v2_address;
     this.farmName;
   }
+
+  // Watchers
+  @Watch("$route.query.twinID") async onPropertyChanged(
+    value: number,
+    oldValue: number
+  ) {
+    console.log(
+      `switching from account ${oldValue} farms to account ${value} farms`
+    );
+    this.farms = await getFarm(this.$api, value);
+
+    await this.getNodes();
+  }
+  @Watch("farms.length") async onFarmCreation(value: number, oldValue: number) {
+    console.log(`there were ${oldValue} farms, now there is ${value} farms`);
+  }
+  @Watch("nodes.length") async onNodeDeleted(value: number, oldValue: number) {
+    console.log(`there were ${oldValue} nodes, now there is ${value} nodes`);
+  }
+
+  // Searching disable for now.
   public filteredFarms() {
     if (this.farms.length > 0) {
       return this.farms.filter(
@@ -372,18 +415,40 @@ export default class FarmsView extends Vue {
     }
     return this.farms;
   }
-  async getNodes() {
-    if(this.farms != 0){ 
-      console.log("this.farms", this.farms.length)
-      this.nodes = await getNodesByFarmID(this.farms);
-    }
-    this.loadingNodes = false;
 
+  // Node table listing
+  async onOptionChange(pageNumber: number, pageSize: number) {
+    this.page = pageNumber;
+    this.size = pageSize;
+    await this.getNodes();
   }
+
+  async getNodes() {
+    this.farmsIds = this.farms.map((farm: any) => farm.id);
+
+    if (this.farmsIds.length == 0) return
+
+    console.log(
+      `Request nodes with params. farmids: ${this.farmsIds}, page: ${this.page}, size: ${this.size}`
+    );
+
+    this.loadingNodes = true;
+    let { nodes, count } = await getNodesByFarmID(
+      this.farmsIds,
+      this.page,
+      this.size
+    );
+    this.nodes = nodes;
+    this.count = count;
+    this.loadingNodes = false;
+  }
+
+  // Methods
   openDeleteFarm(farm: any) {
     this.farmToDelete = farm;
     this.openDeleteFarmDialog = true;
   }
+
   callDeleteFarm() {
     this.loadingDeleteFarm = true;
     deleteFarm(
@@ -434,6 +499,7 @@ export default class FarmsView extends Vue {
       this.loadingDeleteFarm = false;
     });
   }
+
   deletePublicIP(publicIP: any) {
     this.loadingDeleteIP = true;
     return deleteIP(
@@ -486,6 +552,7 @@ export default class FarmsView extends Vue {
       this.loadingDeleteIP = false;
     });
   }
+
   public createPublicIPs(publicIPs: string[], gateway: string) {
     this.loadingCreateIP = true;
     return new Promise((resolve, reject) => {
@@ -542,6 +609,7 @@ export default class FarmsView extends Vue {
       }
     });
   }
+
   public farmNameCheck() {
     const nameRegex = new RegExp("^[a-zA-Z0-9_-]*$");
     if (nameRegex.test(this.farmName)) {
@@ -553,6 +621,7 @@ export default class FarmsView extends Vue {
       return false;
     }
   }
+
   public createFarmFromName() {
     this.loadingCreateFarm = true;
     createFarm(
@@ -610,6 +679,7 @@ export default class FarmsView extends Vue {
       this.loadingCreateFarm = false;
     });
   }
+
   stellarAddressCheck() {
     const isValid = StrKey.isValidEd25519PublicKey(this.v2_address);
     if (isValid && !this.v2_address.match(/\W/)) {
@@ -618,6 +688,7 @@ export default class FarmsView extends Vue {
       return false;
     }
   }
+
   public addV2Address() {
     this.loadingAddStellar = true;
     setFarmPayoutV2Address(
@@ -682,6 +753,7 @@ export default class FarmsView extends Vue {
   }
 }
 </script>
+
 <style scoped>
 .v2address {
   overflow: hidden;

--- a/src/portal/views/Farms.vue
+++ b/src/portal/views/Farms.vue
@@ -13,12 +13,10 @@
         align-baseline
       "
     >
-      <div v-if="farms.length == 0">
-        <h3>Don't have any farms? Start by creating one:</h3>
-      </div>
-      <div v-if="farms.length != 0">
-        <h3>Create another farm:</h3>
-      </div>
+      <h3 v-if="farms.length == 0">
+        Don't have any farms? Start by creating one:
+      </h3>
+      <h3 v-else>Create another farm:</h3>
 
       <v-btn
         @click="openCreateFarmDialog = true"


### PR DESCRIPTION
### Changes
- edit `create farm` message based on the total number of farms.
- implement pagination in farms nodes table.
- disable sort/search on the nodes table. till implemented on gridproxy

### Related Issues

- https://github.com/threefoldtech/tfgrid_dashboard/issues/387
