### PR TITLE
change metric label to Monitoring

### DIFF
--- a/src/Dashboard.vue
+++ b/src/Dashboard.vue
@@ -452,8 +452,8 @@ export default class Dashboard extends Vue {
       children: [],
     },
     {
-      label: "Monitoring dashboard",
-      icon: "monitor",
+      label: "Monitoring",
+      icon: "equalizer",
       prefix: "https://metrics.grid.tf",
       hyperlink: true,
       children: [],


### PR DESCRIPTION
### Description

As Thabet asked, metrics label changed from Monitoring dashboard to Monitoring

### Related Issues

- Add a link to the monitoring dashboard #439
-  add metrics link to sidebar  #440 


### Checklist


- [x] Build pass
- [x] Code format and docstrings
