### PR TITLE
Fixing twin details

### DIFF
--- a/src/portal/views/Twin.vue
+++ b/src/portal/views/Twin.vue
@@ -44,7 +44,7 @@
         </v-list>
         <v-card-actions class="justify-end">
           <v-btn @click="editTwin" color="primary">Edit</v-btn>
-          <v-btn @click="openDeleteTwin" :loading="loadingDeleteTwin" color="red" class="white--text">Delete</v-btn>
+          <!-- <v-btn @click="openDeleteTwin" :loading="loadingDeleteTwin" color="red" class="white--text">Delete</v-btn> -->
         </v-card-actions>
       </v-card>
     </v-container>


### PR DESCRIPTION
### Description

A farm can be associated to a deleted twin id, so I hid the delete twin id button.
### Changes

Hiding the delete twin id button
### Related Issues

#459