### PR TITLE
Fix transfer section, the balance field has an issue.

### DIFF
--- a/src/Dashboard.vue
+++ b/src/Dashboard.vue
@@ -346,19 +346,17 @@ export default class Dashboard extends Vue {
     this.balance = await getBalance(this.$api, address);
     if (this.twinID) {
       this.twin = await getTwin(this.$api, this.twinID);
-      if (!this.$route.path.includes(path) || this.$route.params.accountID !== address) {
-        this.$router.push({
-          name: `${path}`,
-          params: { accountID: `${address}` },
-          query: {
-            accountName: `${name}`,
-            twinID: this.twin.id,
-            twinIP: this.twin.ip,
-            balanceFree: `${this.balance.free}`,
-            balanceReserved: `${this.balance.reserved}`,
-          },
-        });
-      }
+      this.$router.push({
+        name: `${path}`,
+        params: { accountID: `${address}` },
+        query: {
+          accountName: `${name}`,
+          twinID: this.twin.id,
+          twinIP: this.twin.ip,
+          balanceFree: `${this.balance.free}`,
+          balanceReserved: `${this.balance.reserved}`,
+        },
+      });
     } else {
       if (!this.$route.path.includes(address)) {
         this.$router.push({


### PR DESCRIPTION
### Description
I did a workaround to activate clicked child inside the Portal tab, IDK why we implement it in a different way than `Explorer` or `Calculators`, but I notice that we load `address`, and `balance`..etc from the query params so that's why the twin details were hiding, as I understand in `Vue` there is attr calling `:to` it changes the element to `<a>` then if I added another attr called `:active` it will active the clicked item, but this won't work with the `Portal` section cuz its element is `<div>` and we have to load the params from the location, so that's why I did it, if there is a better solution please suggest it.


### Related Issues:
- https://github.com/threefoldtech/tfgrid_dashboard/issues/467
- https://github.com/threefoldtech/tfgrid_dashboard/issues/464
