### PR TITLE
Edit pk type

### DIFF
--- a/src/portal/lib/twin.ts
+++ b/src/portal/lib/twin.ts
@@ -8,7 +8,7 @@ export async function createTwin(
       tfgridModule: {
         createTwin: (
           arg0: string,
-          arg1: string,
+          arg1: string | null,
         ) => {
           (): any;
           new (): any;
@@ -18,7 +18,7 @@ export async function createTwin(
     };
   },
   relay: string,
-  pk: string,
+  pk: string | null,
   callback: any,
 ) {
   const injector = await web3FromAddress(address);
@@ -42,7 +42,7 @@ export async function updateRelay(
       tfgridModule: {
         updateTwin: (
           arg0: string,
-          arg1: string,
+          arg1: string | null,
         ) => {
           (): any;
           new (): any;
@@ -52,7 +52,7 @@ export async function updateRelay(
     };
   },
   relay: string,
-  pk: string,
+  pk: string | null,
   callback: any,
   errc?: any,
 ) {

--- a/src/portal/store/state.ts
+++ b/src/portal/store/state.ts
@@ -18,6 +18,6 @@ export declare type UserCredentials = {
   twinID: number;
   balanceFree: number;
   balanceReserved: number;
-  relayAddress: string;
-  publicKey: string;
+  relayAddress: string | null;
+  publicKey: string | null;
 };

--- a/src/portal/views/Account.vue
+++ b/src/portal/views/Account.vue
@@ -104,7 +104,7 @@ export default class AccountView extends Vue {
     item_id: 1,
   };
   selectedName = "";
-  pk = "";
+  pk = null;
 
   async updated() {
     if (this.$api && this.$credentials) {
@@ -156,7 +156,7 @@ export default class AccountView extends Vue {
     this.twinID = 0;
   }
 
-  public async createTwinFunc(relay: string, pk: string) {
+  public async createTwinFunc(relay: string, pk: string | null) {
     this.loadingTwinCreate = true;
     await createTwin(
       this.address,

--- a/src/portal/views/Twin.vue
+++ b/src/portal/views/Twin.vue
@@ -87,9 +87,9 @@ export default class TwinView extends Vue {
   $api: any;
   $credentials!: UserCredentials;
   editingTwin = false;
-  twin: { relay: string | (string | null)[]; pk: string; address: string; id: string | (string | null)[] } = {
+  twin: { relay: string | null; pk: string | null; address: string; id: string | null } = {
     relay: "",
-    pk: "",
+    pk: null,
     id: "",
     address: "",
   };
@@ -108,6 +108,7 @@ export default class TwinView extends Vue {
     this.twin.id = String(this.$credentials.twinID);
     this.accountName = this.$credentials.accountName;
     this.twin.relay = this.$credentials.relayAddress;
+    this.twin.pk = this.$credentials.publicKey;
     this.selectedName = this.items.filter(item => item.id === this.selectedItem.item_id)[0].name;
   }
   mounted() {
@@ -165,10 +166,12 @@ export default class TwinView extends Vue {
                 this.twin = await getTwin(this.$api, parseFloat(`${this.twin.id}`));
                 this.editingTwin = false;
                 this.$credentials.relayAddress = this.selectedName;
+                this.$credentials.publicKey = this.twin.pk;
               } else if (section === "system" && method === "ExtrinsicFailed") {
                 this.$toasted.show("Twin creation/update failed!");
                 this.loadingEditTwin = false;
                 this.twin.relay = this.$credentials.relayAddress;
+                this.twin.pk = this.$credentials.publicKey;
               }
             });
           }
@@ -179,6 +182,7 @@ export default class TwinView extends Vue {
       this.$toasted.show("Twin creation/update failed!");
       this.loadingEditTwin = false;
       this.twin.relay = this.$credentials.relayAddress;
+      this.twin.pk = this.$credentials.publicKey;
     });
   }
   openDeleteTwin() {


### PR DESCRIPTION
### Description

Edit pk on update twin to be null instead of empty string

### Changes

- edit all twin details types
- set pk to null instead of empty string in create/update twin

### Related Issues

- https://github.com/threefoldtech/tfgrid_dashboard/issues/522

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
