### PR TITLE
Fixing node up-time

### DIFF
--- a/src/Dashboard.vue
+++ b/src/Dashboard.vue
@@ -285,7 +285,6 @@ export default class Dashboard extends Vue {
   }
 
   async unmounted() {
-    console.log(`disconnecting from api`);
     await this.$api.disconnect();
     this.$store.dispatch("portal/unsubscribeAccounts");
     this.$store.commit("UNSET_CREDENTIALS");

--- a/src/Dashboard.vue
+++ b/src/Dashboard.vue
@@ -223,10 +223,6 @@ interface SidenavItem {
   components: { WelcomeWindow, FundsCard },
 })
 export default class Dashboard extends Vue {
-  vText(vText: any) {
-    throw new Error("Method not implemented.");
-  }
-
   collapseOnScroll = true;
   mini = true;
   drawer = true;
@@ -240,7 +236,6 @@ export default class Dashboard extends Vue {
     this.accounts = this.$store.state.portal.accounts;
     if (this.$route.path === "/" && !this.$api) {
       Vue.prototype.$api = await connect();
-      console.log(`connecting to api`);
       this.loadingAPI = false;
     }
     const theme = localStorage.getItem("dark_theme");

--- a/src/explorer/components/DetailsV2.vue
+++ b/src/explorer/components/DetailsV2.vue
@@ -116,8 +116,8 @@ export default class Details extends Vue {
           this.data.node.status = this.data.node.status === "up";
         }
       })
-      .catch(err => {
-        console.log("Error", err);
+      .catch(() => {
+        /* pass */
       })
       .finally(() => {
         this.loading = false;

--- a/src/explorer/components/NodeDetails.vue
+++ b/src/explorer/components/NodeDetails.vue
@@ -276,12 +276,14 @@ export default class NodeDetails_ extends Vue {
         if ("Error" in res) return;
         return res.zosVersion;
       })
-      .catch(err => console.log("something went wrong", err));
+      .catch(() => {
+        /* Pass */
+      });
   }
   created() {
     if (isNodeOnline(this.node)) {
       this.getZOSVersion(this.node.nodeId).then(zosVersion => {
-        if (zosVersion) this.zosVersion = zosVersion!;
+        if (zosVersion) this.zosVersion = zosVersion;
       });
     }
   }

--- a/src/explorer/components/NodeUsedResources.vue
+++ b/src/explorer/components/NodeUsedResources.vue
@@ -63,7 +63,7 @@ export default class NodeUsedResources extends Vue {
     return this.node.status;
   }
 
-  getNodeUsedResources(nodeId: number) {
+  getNodeUsedResources() {
     this.loader = true;
 
     return ["cru", "sru", "hru", "mru"].map((i, idx) => {
@@ -81,7 +81,7 @@ export default class NodeUsedResources extends Vue {
   }
   created() {
     if (this.nodeStatus) {
-      const resources = this.getNodeUsedResources(this.node.nodeId);
+      const resources = this.getNodeUsedResources();
       if (resources) {
         this.resources = resources;
       }

--- a/src/explorer/components/Sidebar.vue
+++ b/src/explorer/components/Sidebar.vue
@@ -32,12 +32,6 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
-import { ApiPromise, WsProvider } from "@polkadot/api";
-
-interface IVersion {
-  name: string;
-  value: string;
-}
 
 @Component({})
 export default class Sidebar extends Vue {

--- a/src/explorer/store/actions.ts
+++ b/src/explorer/store/actions.ts
@@ -120,11 +120,10 @@ export default {
       .then(data => {
         commit(MutationTypes.SET_DATA, data);
       })
-      .catch(err => {
+      .catch(() => {
         /**
          * @todo Should handle this error nicely. :"(
          */
-        console.log("something went wrong", err);
       })
       .finally(() => {
         commit(MutationTypes.SET_LOAD, false);

--- a/src/explorer/store/getters.ts
+++ b/src/explorer/store/getters.ts
@@ -40,9 +40,6 @@ export function fallbackDataExtractor(key: any, state?: any) {
   return (state: any) => state.data?.[key] ?? [];
 }
 
-export function getTotalCPUs(state: IState) {
-  const nodes: any | undefined = state.data?.nodes;
-}
 function isPrivateIP(ip: string) {
   const parts = ip.split(".");
   return (
@@ -50,19 +47,6 @@ function isPrivateIP(ip: string) {
     (parts[0] === "172" && parseInt(parts[1], 10) >= 16 && parseInt(parts[1], 10) <= 31) ||
     (parts[0] === "192" && parts[1] === "168")
   );
-}
-function getAccessNodesCount(nodes: INode[]) {
-  return nodes.reduce((total, node) => {
-    if (node.publicConfig?.ipv4 && !isPrivateIP(node.publicConfig.ipv4)) total += 1;
-    return total;
-  }, 0);
-}
-
-function getGatewaysCount(nodes: INode[]) {
-  return nodes.reduce((total, node) => {
-    if (node.publicConfig?.ipv4 && !isPrivateIP(node.publicConfig.ipv4) && node.publicConfig.domain) total += 1;
-    return total;
-  }, 0);
 }
 
 export function getFarmPublicIPs(state: IState, farmId: number): [number, number, number] {

--- a/src/explorer/store/getters.ts
+++ b/src/explorer/store/getters.ts
@@ -1,4 +1,4 @@
-import { GetDataQueryType, INode } from "../graphql/api";
+import { GetDataQueryType } from "../graphql/api";
 import { applyFilters, comparisonFilter, conditionFilter, inFilter, rangeFilter } from "../utils/filters";
 import { GetterTree } from "vuex";
 import { IState } from "./state";
@@ -38,15 +38,6 @@ export function fallbackDataExtractor<T = GetDataQueryType, K extends keyof T = 
 export function fallbackDataExtractor(key: any, state?: any) {
   if (state) return state.data?.[key] ?? [];
   return (state: any) => state.data?.[key] ?? [];
-}
-
-function isPrivateIP(ip: string) {
-  const parts = ip.split(".");
-  return (
-    parts[0] === "10" ||
-    (parts[0] === "172" && parseInt(parts[1], 10) >= 16 && parseInt(parts[1], 10) <= 31) ||
-    (parts[0] === "192" && parts[1] === "168")
-  );
 }
 
 export function getFarmPublicIPs(state: IState, farmId: number): [number, number, number] {

--- a/src/explorer/store/state.ts
+++ b/src/explorer/store/state.ts
@@ -12,23 +12,6 @@ interface IFilter {
 }
 const createFilter = () => ({ enabled: false, value: [] });
 
-interface IRangeFilter {
-  enabled: boolean;
-  value: {
-    min: number;
-    max: number;
-  };
-}
-// prettier-ignore
-const createRangeFilter = () => ({ enabled: false, value: { min: 0, max: Number.MAX_SAFE_INTEGER } });
-
-interface IConditionFilter {
-  enabled: boolean;
-  value: boolean;
-}
-
-const createConditionFilter = () => ({ enabled: false, value: true });
-
 interface IComparisonFilter {
   enabled: boolean;
   value: number;

--- a/src/explorer/utils/getChainData.ts
+++ b/src/explorer/utils/getChainData.ts
@@ -29,7 +29,7 @@ function getPricingPolicies(provider: WsProvider): Promise<Map<number, string>> 
     .then(api => {
       return api.query.tfgridModule.pricingPolicies.entries();
     })
-    .then(([[_, res]]) => res.toHuman())
+    .then(([x]) => x[1].toHuman())
     .then((certs: any) => {
       const map = new Map();
       certs = Array.isArray(certs) ? certs : [certs];

--- a/src/explorer/utils/getPricingPolicies.ts
+++ b/src/explorer/utils/getPricingPolicies.ts
@@ -13,8 +13,8 @@ export default function getPricingPolicies(): Promise<Map<number, string>> {
     .then((api: any) => {
       return api.query.tfgridModule.pricingPolicies.entries();
     })
-    .then(([[_, ...entries]]: any) => {
-      return entries.reduce(
+    .then(([x]: any) => {
+      return x.slice(1).reduce(
         (
           map: any,
           {

--- a/src/explorer/views/Farms.vue
+++ b/src/explorer/views/Farms.vue
@@ -176,8 +176,8 @@ export default class Farms extends Vue {
           };
         },
       )
-      .catch(err => {
-        console.log("Error", err);
+      .catch(() => {
+        /* Pass */
       })
       .finally(() => {
         this.loading = false;
@@ -258,7 +258,7 @@ export default class Farms extends Vue {
       component: InFilterV2,
       chip_label: "Twin ID",
       label: "Filter By Twin ID",
-      items: _ => Promise.resolve([]),
+      items: () => Promise.resolve([]),
       value: [],
       multiple: false,
       symbol: "twinId_in",
@@ -271,7 +271,7 @@ export default class Farms extends Vue {
       component: InFilterV2,
       chip_label: "Certification Type",
       label: "Filter By Certification Type",
-      items: _ => Promise.resolve(["Gold", "NotCertified"]),
+      items: () => Promise.resolve(["Gold", "NotCertified"]),
       value: [],
       init: true,
       multiple: false,
@@ -282,7 +282,7 @@ export default class Farms extends Vue {
       component: InFilterV2,
       chip_label: "Pricing Policy",
       label: "Filter By Pricing policy",
-      items: _ => Promise.resolve(this.$store.state.explorer.pricingPoliciesIds),
+      items: () => Promise.resolve(this.$store.state.explorer.pricingPoliciesIds),
       value: [],
       init: true,
       multiple: true,

--- a/src/explorer/views/Statistics.vue
+++ b/src/explorer/views/Statistics.vue
@@ -90,7 +90,9 @@ export default class Statistics extends Vue {
     req
       .get("/stats?status=up")
       .then(({ data }) => (this.stats = data))
-      .catch(console.log)
+      .catch(() => {
+        /* Pass */
+      })
       .finally(() => (this.loading = false));
   }
 }

--- a/src/hub/utils/test.ts
+++ b/src/hub/utils/test.ts
@@ -1,11 +1,5 @@
 import { snakeToCamelCase } from "./camel";
 
-function assertEq(found: any, expected: any, msg?: string) {
-  if (found != expected) {
-    throw new Error(msg + ": found " + found + ", expected " + expected);
-  }
-}
-
 function assert(expr: boolean, msg?: string) {
   if (!expr) {
     throw new Error(msg);

--- a/src/portal/components/FarmNodesTable.vue
+++ b/src/portal/components/FarmNodesTable.vue
@@ -130,7 +130,7 @@
                     <span>For more information visit the Capacity Explorer</span>
                   </v-row>
                 </v-col>
-                <v-col v-if="network == 'main'" cols="4" class="text-center" :align-self="'center'">
+                <v-col cols="4" class="text-center" :align-self="'center'">
                   <v-flex class="text-truncate font-weight-bold">
                     <v-tooltip bottom>
                       <template v-slot:activator="{ on }">
@@ -145,7 +145,7 @@
 
                         <span> Uptime: {{ getNodeUptimePercentage(item) }} % </span>
                       </template>
-                      <span>Current Node Uptime Percentage (since start of the month)</span>
+                      <span>Current Node Uptime Percentage (since start of the current minting period)</span>
                     </v-tooltip>
                   </v-flex>
                 </v-col>

--- a/src/portal/components/FarmNodesTable.vue
+++ b/src/portal/components/FarmNodesTable.vue
@@ -531,9 +531,7 @@ export default class FarmNodesTable extends Vue {
       this.nodeToEdit.nodeId,
       config,
       (res: { events?: never[] | undefined; status: { type: string; asFinalized: string; isFinalized: string } }) => {
-        console.log(res);
         if (res instanceof Error) {
-          console.log(res);
           this.ip4 = "";
           this.ip6 = "";
           this.gw4 = "";
@@ -542,13 +540,11 @@ export default class FarmNodesTable extends Vue {
           return;
         }
         const { events = [], status } = res;
-        console.log(`Current status is ${status.type}`);
         switch (status.type) {
           case "Ready":
             this.$toasted.show(`Transaction submitted`);
         }
         if (status.isFinalized) {
-          console.log(`Transaction included at blockHash ${status.asFinalized}`);
           if (!events.length) {
             if (this.openWarningDialog) this.$toasted.show("Adding Node public config failed");
             else if (this.openRemoveConfigWarningDialog) this.$toasted.show("Removing Node public config failed");
@@ -558,8 +554,7 @@ export default class FarmNodesTable extends Vue {
             this.openRemoveConfigWarningDialog = false;
           } else {
             // Loop through Vec<EventRecord> to display all events
-            events.forEach(({ phase, event: { data, method, section } }) => {
-              console.log(`\t' ${phase}: ${section}.${method}:: ${data}`);
+            events.forEach(({ event: { method, section } }) => {
               if (section === "tfgridModule" && method === "NodePublicConfigStored") {
                 if (this.openWarningDialog) this.$toasted.show("Node public config added!");
                 else if (this.openRemoveConfigWarningDialog) {
@@ -586,8 +581,7 @@ export default class FarmNodesTable extends Vue {
           }
         }
       },
-    ).catch((err: { message: string }) => {
-      console.log(err.message);
+    ).catch(() => {
       if (this.openWarningDialog) this.$toasted.show("Adding Node public config failed");
       else if (this.openRemoveConfigWarningDialog) this.$toasted.show("Removing Node public config failed");
       this.loadingPublicConfig = false;
@@ -736,22 +730,17 @@ export default class FarmNodesTable extends Vue {
       this.$api,
       parseInt(this.nodeToDelete.id.split("-")[1]),
       (res: { events?: never[] | undefined; status: { type: string; asFinalized: string; isFinalized: string } }) => {
-        console.log(res);
         if (res instanceof Error) {
-          console.log(res);
           return;
         }
         const { events = [], status } = res;
-        console.log(`Current status is ${status.type}`);
         switch (status.type) {
           case "Ready":
             this.$toasted.show(`Transaction submitted`);
         }
         if (status.isFinalized) {
-          console.log(`Transaction included at blockHash ${status.asFinalized}`);
           // Loop through Vec<EventRecord> to display all events
-          events.forEach(({ phase, event: { data, method, section } }) => {
-            console.log(`\t' ${phase}: ${section}.${method}:: ${data}`);
+          events.forEach(({ event: { method, section } }) => {
             if (section === "tfgridModule" && method === "NodeDeleted") {
               this.$toasted.show("Node deleted!");
               this.loadingDelete = false;
@@ -764,8 +753,7 @@ export default class FarmNodesTable extends Vue {
           });
         }
       },
-    ).catch((err: { message: string }) => {
-      console.log(err.message);
+    ).catch(() => {
       this.$toasted.show("Deleting a node failed");
       this.loadingDelete = false;
     });

--- a/src/portal/components/FarmNodesTable.vue
+++ b/src/portal/components/FarmNodesTable.vue
@@ -421,7 +421,7 @@ export default class FarmNodesTable extends Vue {
     rentedByTwinId: 0,
     receipts: [],
     serialNumber: "",
-    downtime: 0,
+    availability: { downtime: 0, currentPeriod: 0 },
   };
   nodeToDelete: { id: string } = {
     id: "",

--- a/src/portal/lib/farms.ts
+++ b/src/portal/lib/farms.ts
@@ -2,7 +2,7 @@ import { Signer } from "@polkadot/api/types";
 import { web3FromAddress } from "@polkadot/extension-dapp";
 import axios from "axios";
 import config from "../config";
-import { getNodeDowntime } from "./nodes";
+import { getNodeAvailability, NodeAvailability } from "./nodes";
 import { getNodeMintingFixupReceipts, receiptInterface } from "./nodes";
 import { hex2a } from "./util";
 export interface nodeInterface {
@@ -47,7 +47,7 @@ export interface nodeInterface {
   rentedByTwinId: number;
   receipts: receiptInterface[];
   serialNumber: string;
-  downtime: number;
+  availability: NodeAvailability;
 }
 export async function getFarm(api: { query: any }, twinID: number) {
   const farms = await api.query.tfgridModule.farms.entries();
@@ -270,7 +270,7 @@ export async function getNodesByFarmID(farmIDs: any[], page: number, size: numbe
       const network = config.network;
       node.receipts = [];
       if (network == "main") node.receipts = await getNodeMintingFixupReceipts(node.nodeId);
-      node.downtime = await getNodeDowntime(node.nodeId);
+      node.availability = await getNodeAvailability(node.nodeId);
     } catch (error) {
       node.receipts = [];
       node.used_resources = {
@@ -279,7 +279,7 @@ export async function getNodesByFarmID(farmIDs: any[], page: number, size: numbe
         mru: 0,
         cru: 0,
       };
-      node.downtime = 0;
+      node.availability = { downtime: 0, currentPeriod: 0 };
     }
 
     return node;

--- a/src/portal/lib/nodes.ts
+++ b/src/portal/lib/nodes.ts
@@ -53,7 +53,6 @@ export async function getNodeAvailability(nodeId: number) {
     query: `{
 			uptimeEvents(where: {nodeID_eq: ${nodeId}, timestamp_gt: ${currentPeriodStartTimestamp}}, orderBy: timestamp_ASC) {
 			  timestamp
-			  nodeID
 			  uptime
 			}
 		  }`,
@@ -62,6 +61,9 @@ export async function getNodeAvailability(nodeId: number) {
 
   // if there are no uptimeEvents (i.e node was never up in the current period), return the time elapsed since the period start as downtime
   if (uptimeEvents.length == 0) {
+    console.log(
+      `getNodeAvailability: Node ${nodeId} didn't send uptime events for the last ${secondsSinceCurrentPeriodStart} seconds.`,
+    );
     return { downtime: secondsSinceCurrentPeriodStart, currentPeriod: secondsSinceCurrentPeriodStart };
   }
 
@@ -79,10 +81,13 @@ export async function getNodeAvailability(nodeId: number) {
     }
   }
 
-  const elapsedSinceLastUptimeEvent = secondsSinceEpoch - uptimeEvents[-1].timestamp;
+  const elapsedSinceLastUptimeEvent = secondsSinceEpoch - uptimeEvents[uptimeEvents.length - 1].timestamp;
   if (elapsedSinceLastUptimeEvent >= UPTIME_EVENTS_INTERVAL) {
     downtime += elapsedSinceLastUptimeEvent;
   }
+  console.log(
+    `getNodeAvailability: Node ${nodeId} was down for ${downtime} seconds in the last ${secondsSinceCurrentPeriodStart} seconds.`,
+  );
   return { downtime: downtime, currentPeriod: secondsSinceCurrentPeriodStart };
 }
 

--- a/src/portal/lib/nodes.ts
+++ b/src/portal/lib/nodes.ts
@@ -9,6 +9,7 @@ import { nodeInterface } from "./farms";
 import moment from "moment";
 import "jspdf-autotable";
 import { apiInterface } from "./util";
+import { Any } from "@/hub/types/google/protobuf/any";
 export interface receiptInterface {
   hash: string;
   mintingStart?: number;
@@ -18,44 +19,78 @@ export interface receiptInterface {
   fixupEnd?: number;
   tft?: number;
 }
-export async function getNodeDowntime(nodeId: number) {
-  const today = new Date();
+interface UptimeEvent {
+  uptime: number;
+  timestamp: number;
+}
 
-  const periodStart = new Date(today.getFullYear(), today.getMonth(), 1).getTime();
+export interface NodeAvailability {
+  downtime: number;
+  currentPeriod: number;
+}
+
+export async function getNodeAvailability(nodeId: number) {
+  /**
+   * Return Node availability over the current minting period
+   *
+   * @param nodeId - The node id
+   * @returns node downtime and uptime in current minting period
+   * */
+
+  // The duration of a standard period, as used by the minting payouts, in seconds
+  // https://github.com/threefoldtech/minting_v3/blob/master/src/period.rs
+  const STANDARD_PERIOD_DURATION = (24 * 60 * 60 * (365 * 3 + 366 * 2)) / 60;
+  // Timestamp of the start of the first period in seconds
+  const FIRST_PERIOD_START_TIMESTAMP = 1522501000;
+  const secondsSinceEpoch = Math.round(Date.now() / 1000);
+  const offset = (secondsSinceEpoch - FIRST_PERIOD_START_TIMESTAMP) / STANDARD_PERIOD_DURATION;
+  const periodStart = FIRST_PERIOD_START_TIMESTAMP + STANDARD_PERIOD_DURATION * offset;
+  const elapsedSincePeriodStart = secondsSinceEpoch - periodStart;
 
   const res = await axios.post(config.graphqlUrl, {
     query: `{
-			uptimeEvents(where: {nodeID_eq: ${nodeId}, timestamp_gt: ${periodStart / 1000}}, orderBy: timestamp_ASC) {
+			uptimeEvents(where: {nodeID_eq: ${nodeId}, timestamp_gt: ${periodStart}}, orderBy: timestamp_ASC) {
 			  timestamp
 			  nodeID
 			  uptime
 			}
 		  }`,
   });
-  const uptimeEvents = res.data.data.uptimeEvents;
+  const uptimeEvents: Array<UptimeEvent> = res.data.data.uptimeEvents;
+
+  // if there are no uptimeEvents (i.e node was never up in the current period), return the time elapsed since the period start as downtime
+  if (uptimeEvents.length == 0) {
+    return { downtime: elapsedSincePeriodStart, currentPeriod: elapsedSincePeriodStart };
+  }
+
+  const fakeDataPoint = { timestamp: periodStart, uptime: 0 };
+  uptimeEvents.unshift(fakeDataPoint);
 
   let downtime = 0;
-  // if there are no uptimeEvents (i.e node was never up in the current period), return a very large downtime number to achieve 0% uptime percentage
-  if (uptimeEvents.length == 0) {
-    return 10e100;
-  }
   for (let i = 0; i < uptimeEvents.length - 1; i++) {
     // if uptime decreases with time, then node was down in that time period, so add time period to node downtime
-    if (uptimeEvents[i].uptime > uptimeEvents[i + 1].uptime) {
-      downtime += uptimeEvents[i + 1].timestamp - uptimeEvents[i].timestamp;
+    if (
+      uptimeEvents[i].uptime > uptimeEvents[i + 1].uptime ||
+      uptimeEvents[i + 1].uptime < uptimeEvents[i + 1].timestamp - uptimeEvents[i].timestamp
+    ) {
+      downtime += uptimeEvents[i + 1].timestamp - uptimeEvents[i].timestamp - uptimeEvents[i + 1].uptime;
     }
   }
 
-  return downtime;
+  const elapsedSinceLastUptimeEvent = secondsSinceEpoch - uptimeEvents[-1].timestamp;
+  if (elapsedSinceLastUptimeEvent >= 60) {
+    downtime += elapsedSinceLastUptimeEvent;
+  }
+  return { downtime: downtime, currentPeriod: elapsedSincePeriodStart };
 }
+
 export function getNodeUptimePercentage(node: nodeInterface) {
-  return ((node.uptime / (node.uptime + node.downtime)) * 100).toFixed(2);
+  return (
+    ((node.availability.currentPeriod - node.availability.downtime) / node.availability.currentPeriod) *
+    100
+  ).toFixed(2);
 }
-interface uptimeEventInterface {
-  timestamp: number;
-  nodeID: string;
-  uptime: number;
-}
+
 export function getTime(num: number | undefined) {
   if (num) {
     return new Date(num);

--- a/src/portal/lib/nodes.ts
+++ b/src/portal/lib/nodes.ts
@@ -46,9 +46,9 @@ export async function getNodeAvailability(nodeId: number) {
   // here we set this to one hour (3600 sec) to allow some room.
   const UPTIME_EVENTS_INTERVAL = 3600;
   const secondsSinceEpoch = Math.round(Date.now() / 1000);
-  const offset = (secondsSinceEpoch - FIRST_PERIOD_START_TIMESTAMP) / STANDARD_PERIOD_DURATION;
-  const periodStart = FIRST_PERIOD_START_TIMESTAMP + STANDARD_PERIOD_DURATION * offset;
-  const elapsedSincePeriodStart = secondsSinceEpoch - periodStart;
+  const elapsedSincePeriodStart = (secondsSinceEpoch - FIRST_PERIOD_START_TIMESTAMP) % STANDARD_PERIOD_DURATION;
+  // const periodStart = FIRST_PERIOD_START_TIMESTAMP + STANDARD_PERIOD_DURATION * offset;
+  const periodStart = secondsSinceEpoch - elapsedSincePeriodStart;
 
   const res = await axios.post(config.graphqlUrl, {
     query: `{

--- a/src/portal/lib/nodes.ts
+++ b/src/portal/lib/nodes.ts
@@ -34,7 +34,7 @@ export async function getNodeAvailability(nodeId: number) {
    * Return Node availability over the current minting period
    *
    * @param nodeId - The node id
-   * @returns node downtime and uptime in current minting period
+   * @returns node downtime and elapsed time in seconds since current minting period started (which the downtime was calculated over)
    * */
 
   // The duration of a standard period, as used by the minting payouts, in seconds
@@ -42,6 +42,9 @@ export async function getNodeAvailability(nodeId: number) {
   const STANDARD_PERIOD_DURATION = (24 * 60 * 60 * (365 * 3 + 366 * 2)) / 60;
   // Timestamp of the start of the first period in seconds
   const FIRST_PERIOD_START_TIMESTAMP = 1522501000;
+  // uptime events are supposed to happen every 40 minutes.
+  // here we set this to one hour (3600 sec) to allow some room.
+  const UPTIME_EVENTS_INTERVAL = 3600;
   const secondsSinceEpoch = Math.round(Date.now() / 1000);
   const offset = (secondsSinceEpoch - FIRST_PERIOD_START_TIMESTAMP) / STANDARD_PERIOD_DURATION;
   const periodStart = FIRST_PERIOD_START_TIMESTAMP + STANDARD_PERIOD_DURATION * offset;
@@ -78,7 +81,7 @@ export async function getNodeAvailability(nodeId: number) {
   }
 
   const elapsedSinceLastUptimeEvent = secondsSinceEpoch - uptimeEvents[-1].timestamp;
-  if (elapsedSinceLastUptimeEvent >= 60) {
+  if (elapsedSinceLastUptimeEvent >= UPTIME_EVENTS_INTERVAL) {
     downtime += elapsedSinceLastUptimeEvent;
   }
   return { downtime: downtime, currentPeriod: elapsedSincePeriodStart };


### PR DESCRIPTION
### Description

Fixing node's availability calculations. 
should now calculate the uptime over the current minting period.

The Calculations are based on my understanding of @LeeSmet comment [here] (https://github.com/threefoldtech/tfgrid_dashboard/issues/366#issuecomment-1304436906)
 
### Changes

- Function `getNodeDowntime` is renamed to `getNodeAvailability` and now returns both downtime and the time elapsed since the current minting period started.
- Downtime is now calculated over the **current minting period**.
- The node interface has been changed to include an `availability` attribute with a new `NodeAvailability` interface instead of a `downtime` attribute.
- Uptime percentage is now calculated based on calculated `node.availability`  `((uptime over the current minting period / current minting period) * 100)`, instead of `node.uptime` (which is the uptime since the node's last reboot).
- Showing the uptime percentage now **enabled on all networks**. before it was limited to only the main net.

### Related Issues

https://github.com/threefoldtech/tfgrid_dashboard/issues/466

### Checklist

- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstrings
