### PR TITLE
remove repeated requests on Dedicated node page

### DIFF
--- a/src/portal/components/NodesTable.vue
+++ b/src/portal/components/NodesTable.vue
@@ -116,7 +116,6 @@ export default class NodesTable extends Vue {
 
   async mounted() {
     this.address = this.$route.params.accountID;
-    await this.getNodes();
   }
 
   async onUpdateOptions(pageNumber: number, pageSize: number) {

--- a/src/portal/views/Nodes.vue
+++ b/src/portal/views/Nodes.vue
@@ -6,12 +6,11 @@
           {{ tab.label }}
         </v-tab>
       </v-tabs>
-
-      <v-tabs-items v-model="activeTab">
-        <v-tab-item v-for="tab in tabs" :key="tab.index" :value="tab.query">
-          <NodesTable :tab="tab" :twinId="$store.state.credentials.twin.id" :trigger="trigger" />
-        </v-tab-item>
-      </v-tabs-items>
+      <NodesTable
+        :tab="tabs.find(tab => tab.query === activeTab)"
+        :twinId="$store.state.credentials.twin.id"
+        :trigger="trigger"
+      />
     </v-card>
   </v-container>
 </template>
@@ -26,9 +25,6 @@ import { ITab } from "../lib/nodes";
   components: { NodesTable },
 })
 export default class NodesView extends Vue {
-  $api = "";
-  activeTab = "";
-  trigger = "";
   tabs: ITab[] = [
     {
       label: "Rentable",
@@ -49,6 +45,9 @@ export default class NodesView extends Vue {
       index: 3,
     },
   ];
+  $api = "";
+  activeTab = this.tabs[0].query;
+  trigger = "";
 
   mounted() {
     if (!(this.$api && this.$store.state.credentials.initialized)) {


### PR DESCRIPTION
### Description

To prevent repeated requests, some changes were made to enhance the `Dedicated nodes page` performance 

### Changes

remove `get_node` from onmount,
change the way of passing tabs inside `nodeView`

### Related Issues
- https://github.com/threefoldtech/tfgrid_dashboard/issues/561
- https://github.com/threefoldtech/tfgrid_dashboard/issues/527


### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
