### PR TITLE
Adding required env vars to the helm chart

### DIFF
--- a/charts/tfgrid-dashboard/templates/deployment.yaml
+++ b/charts/tfgrid-dashboard/templates/deployment.yaml
@@ -33,8 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
-            - name: GQL_URL
-              value: {{ .Values.GQL_URL }}
+          {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+          {{- end }}
             - name: VERSION
               value: {{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/tfgrid-dashboard/values.yaml
+++ b/charts/tfgrid-dashboard/values.yaml
@@ -9,7 +9,11 @@ image:
   pullPolicy: Always
   tag: "v1.4.0-rc4"
 
-  env:          
+  env:
+    - name: "STELLAR_NETWORK"
+      value: ""
+    - name: "TFCHAIN_NETWORK"
+      value: ""          
     - name: "GRAPHQL_URL"
       value: ""
     - name: "BRIDGE_TFT_ADDRESS"

--- a/charts/tfgrid-dashboard/values.yaml
+++ b/charts/tfgrid-dashboard/values.yaml
@@ -9,6 +9,22 @@ image:
   pullPolicy: Always
   tag: "v1.4.0-rc4"
 
+  env:          
+    - name: "GRAPHQL_URL"
+      value: ""
+    - name: "BRIDGE_TFT_ADDRESS"
+      value: ""
+    - name: "GRIDPROXY_URL"
+      value: ""
+    - name: "SUBSTRATE_URL"
+      value: ""
+    - name: "ACTIVATION_SERVICE_URL"
+      value: ""
+    - name: "PLAYGROUND_URL"
+      value: ""
+    - name: "RELAY_DOMAIN"
+      value: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
### Description

Adding env vars to the helm chart

### Changes

- Adding the required env vars to `values.yaml`
  - STELLAR_NETWORK
  - TFCHAIN_NETWORK
  - GRAPHQL_URL
  - BRIDGE_TFT_ADDRESS
  - GRIDPROXY_URL
  - VERSION
  - SUBSTRATE_URL
  - ACTIVATION_SERVICE_URL
  - PLAYGROUND_URL
  - RELAY_DOMAIN
- modifying the deployment template to read env vars from `values.yaml` file

### Related Issues

https://github.com/threefoldtech/tf_operations/issues/1495

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
