### PR TITLE
remove unnecesasry calls when loading explorer menu

### DIFF
--- a/src/explorer/Explorer.vue
+++ b/src/explorer/Explorer.vue
@@ -21,7 +21,6 @@ export default class App extends Vue {
     this.$store.dispatch(ActionTypes.INIT_POLICIES);
     this.$store.dispatch(ActionTypes.LOAD_CHAIN_DATA);
     this.$store.dispatch(ActionTypes.LOAD_DATA);
-    this.$store.dispatch(ActionTypes.REQUEST_NODES);
     setInterval(() => {
       this.$store.dispatch(ActionTypes.LOAD_DATA);
     }, 5 * 60 * 1000);


### PR DESCRIPTION
### Description

Remove unnecessary calls when loading components under `Explorer` menu.

### Changes

Removed action to fetch node and farms data on every reload of an Explorer component. 

### Related Issues

https://github.com/threefoldtech/tfgrid_dashboard/issues/412

### Checklist

- [x] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
