### PR TITLE
fix explorer farms filtering

### DIFF
--- a/src/explorer/views/Farms.vue
+++ b/src/explorer/views/Farms.vue
@@ -206,7 +206,10 @@ export default class Farms extends Vue {
       .filter(f => (Array.isArray(f.value) ? f.value.length > 0 : true))
       .reduce((res, f) => {
         const { symbol, value, getValue } = f;
-        res[symbol] = getValue?.(f) ?? value;
+        const symbolValue = getValue?.(f) ?? value;
+        if (symbolValue != null && symbolValue != 0) {
+          res[symbol] = symbolValue;
+        }
         return res;
       }, {} as { [key: string]: any });
     this._vars = _vars;


### PR DESCRIPTION
### Description

Fixes an issue where removing a filter in farms explorer page will return no data

### Changes

Removed filter keys when they are removed as a filter as opposed to the old behavior where they were set with either a null or a 0 value.

### Related Issues

https://github.com/threefoldtech/tfgrid_dashboard/issues/498

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
