### PR TITLE
add number of workloads and deployments in node details

### DIFF
--- a/src/explorer/components/DetailsV2.vue
+++ b/src/explorer/components/DetailsV2.vue
@@ -9,7 +9,7 @@
         </v-row>
         <v-row>
           <v-col :cols="screen_max_700.matches ? 12 : screen_max_1200.matches ? 6 : 4" v-if="node">
-            <NodeDetails :node="node" />
+            <NodeDetails :node="node" :nodeStatistics="nodeStatistics" />
           </v-col>
 
           <v-col :cols="screen_max_700.matches ? 12 : screen_max_1200.matches ? 6 : 4" v-if="data.farm">
@@ -59,7 +59,7 @@ import InterfacesDetails from "./InterfacesDetails.vue";
 import NodeUsedResources from "./NodeUsedResources.vue";
 import mediaMatcher from "../utils/mediaMatcher";
 import { DocumentNode } from "graphql";
-import { ICountry, INode } from "../graphql/api";
+import { ICountry, INode, INodeStatistics } from "../graphql/api";
 
 @Component({
   components: {
@@ -85,6 +85,10 @@ export default class Details extends Vue {
 
   get node(): INode {
     return this.data.node;
+  }
+
+  get nodeStatistics(): INodeStatistics {
+    return this.data.nodeStatistics;
   }
 
   get country(): ICountry {
@@ -113,6 +117,9 @@ export default class Details extends Vue {
           this.data.node = await fetch(`${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}`).then(res =>
             res.json(),
           );
+          this.data.nodeStatistics = await fetch(
+            `${window.configs.APP_GRIDPROXY_URL}/nodes/${this.nodeId}/statistics`,
+          ).then(res => res.json());
           this.data.node.status = this.data.node.status === "up";
         }
       })

--- a/src/explorer/components/NodeDetails.vue
+++ b/src/explorer/components/NodeDetails.vue
@@ -96,6 +96,22 @@
           </v-list-item>
           <v-divider />
 
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title> Number of Workloads </v-list-item-title>
+            </v-list-item-content>
+            {{ nodeStatistics.users.workloads }}
+          </v-list-item>
+          <v-divider />
+
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title> Number of Deployments </v-list-item-title>
+            </v-list-item-content>
+            {{ nodeStatistics.users.deployments }}
+          </v-list-item>
+          <v-divider />
+
           <v-list-item v-if="zosVersion">
             <v-list-item-content>
               <v-list-item-title> ZOS Version </v-list-item-title>
@@ -218,7 +234,7 @@
 </template>
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
-import { INode } from "../graphql/api";
+import { INode, INodeStatistics } from "../graphql/api";
 import DatesDetails from "./DatesDetails.vue";
 import mediaMatcher from "../utils/mediaMatcher";
 import isNodeOnline from "../utils/isNodeOnline";
@@ -235,6 +251,7 @@ function createItem(value: string, key?: keyof INode) {
 })
 export default class NodeDetails_ extends Vue {
   @Prop({ required: true }) node!: INode;
+  @Prop({ required: true }) nodeStatistics!: INodeStatistics;
   size = 210;
   width = 10;
   fontSize = 25;

--- a/src/explorer/graphql/api.ts
+++ b/src/explorer/graphql/api.ts
@@ -96,6 +96,15 @@ export interface INode {
   countryFullName: string;
 }
 
+export interface INodeStatisticsUser {
+  deployments: number;
+  workloads: number;
+}
+
+export interface INodeStatistics {
+  users: INodeStatisticsUser;
+}
+
 export const PublicConfigType = gql`
   fragment PublicConfigType on PublicConfig {
     domain


### PR DESCRIPTION
### Description

Show current number of deployment and workloads in node details

### Changes

Make an additional request to get get node workloads and deployments when showing node details in explorer

![image](https://user-images.githubusercontent.com/24762033/226604816-616392b5-1642-458d-8ee0-c68901f583f4.png)


### Related Issues

https://github.com/threefoldtech/tfgrid_dashboard/issues/546

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
