### PR TITLE
avoid unnecessary requests on updated hook 

### DIFF
--- a/src/portal/views/Farms.vue
+++ b/src/portal/views/Farms.vue
@@ -298,15 +298,6 @@ export default class FarmsView extends Vue {
   }
 
   async updated() {
-    if (this.$api) {
-      this.farms = await getFarm(this.$api, this.$store.state.credentials.twin.id);
-      this.loadingFarms = false;
-    } else {
-      this.$router.push({
-        name: "accounts",
-        path: "/",
-      });
-    }
     this.v2_address;
     this.farmName;
   }


### PR DESCRIPTION
### Description

the if-else block is outdated, it was needed when we had multiple accounts in the sidebar. 
and it was making many getFarm requests

### Changes
- remove the if-else block

### Related Issues

- #593

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
