### PR TITLE
Set the default value for the twin public key to null not an empty string

### DIFF
--- a/src/portal/store/credentials.ts
+++ b/src/portal/store/credentials.ts
@@ -30,7 +30,7 @@ export const credentialsStore = {
       twin: {
         relay: "",
         id: "",
-        pk: "",
+        pk: null,
       },
     };
   },


### PR DESCRIPTION
### Description

Set the default value for the twin public key to null not an empty string

### Related Issues

- https://github.com/threefoldtech/rmb_sdk_ts/issues/47

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
