### PR TITLE
fix dao notification

### DIFF
--- a/src/portal/store/actions.ts
+++ b/src/portal/store/actions.ts
@@ -22,6 +22,12 @@ export default {
     const active = (await getProposals(state.api)).active;
     if (!active.length) return;
     const farms = await getFarm(state.api, parseFloat(`${twin}`));
+
+    // only users who own a farm should get the notification
+    if (!farms.length) {
+      commit("setProposals", { proposals: 0 });
+      return;
+    }
     const farmIds = farms.map(function (value) {
       return value.id;
     });
@@ -47,7 +53,6 @@ export default {
     voted.forEach(index => {
       active.splice(index, 1);
     });
-
     commit("setProposals", { proposals: active.length });
   },
 };


### PR DESCRIPTION
### Description

disable the popup if the user has no farms, only users who own a farm should get the notification,

### Changes

set the proposals store to zero if the user has no farms

### Related Issues

- #514 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
