### PR TITLE
Remove the unnecessarily update in the dao view

### DIFF
--- a/src/portal/views/Dao.vue
+++ b/src/portal/views/Dao.vue
@@ -263,16 +263,6 @@ export default class DaoView extends Vue {
       });
     }
   }
-  async updated() {
-    if (this.$api) {
-      this.farms = await getFarm(this.$api, parseFloat(`${this.$store.state.credentials.twin.id}`));
-    } else {
-      this.$router.push({
-        name: "accounts",
-        path: "/",
-      });
-    }
-  }
 
   unmounted() {
     this.$store.commit("UNSET_CREDENTIALS");


### PR DESCRIPTION
### Description

The dao view keeps fetching the farms periodically which makes huge calls to the chain

### Changes

Remove the `updated` part. And if the user adds a new farm to use for voting on a proposal, he has to reload the page then he will find his new farm is added.

### Related Issues

- threefoldtech/tfgrid-sdk-ts#59 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
